### PR TITLE
Remove cookie.allowEmpty

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -34,7 +34,6 @@ var defaultCookie = {
   path: '/',
   overwrite: true,
   signed: true,
-  allowEmpty: false,
   maxAge: 24 * 60 * 60 * 1000 //one day in ms
 };
 


### PR DESCRIPTION
cookie.allowEmpty (not options.allowEmpty) is not used anywhere here, it's also not used in jed/cookies, I wonder is it a mistype?
