### PR TITLE
Delete session-id cookie if session not loaded.

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -148,6 +148,7 @@ module.exports = function (options) {
       session = generateSession();
       // remove session id if no session
       this.sessionId = null;
+      this.cookies.set(key, null);
     }
 
     // get the originHash


### PR DESCRIPTION
To defend against session fixation attacks, delete the session-id cookie if the
store load fails.
