### PR TITLE
Add support for regenerating sessions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ app.use(function *() {
   case '/remove':
     remove.call(this);
     break;
+  case '/regenerate':
+    yield regenerate.call(this);
+    break;
   }
 });
 
@@ -69,12 +72,19 @@ function remove() {
   this.body = 0;
 }
 
+function *regenerate() {
+  get.call(this);
+  yield this.regenerateSession();
+  get.call(this);
+}
+
 app.listen(8080);
 ```
 
 * After adding session middleware, you can use `this.session` to set or get the sessions.
 * Setting `this.session = null;` will destroy this session.
 * Altering `this.session.cookie` changes the cookie options of this user. Also you can use the cookie options in session the store. Use for example `cookie.maxage` as the session store's ttl.
+* Calling `this.regenerateSession` will destroy any existing session and generate a new, empty one in its place. The new session will have a different ID.
 
 ### Options
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -229,6 +229,23 @@ module.exports = function (options) {
     }
 
     this.session = result.session;
+
+    var self = this
+    this.regenerateSession = function *regenerateSession() {
+      debug('regenerating session');
+      if (!result.isNew) {
+        // destroy the old session
+        debug('destroying previous session')
+        yield store.destroy(this.sessionId);
+      }
+
+      self.session = generateSession();
+      self.sessionId = genSid.call(this, 24);
+      self.cookies.set(key, null);
+      debug('created new session: %s', self.sessionId)
+      result.isNew = true;
+    }
+
     yield *next;
     yield *refreshSession.call(this, this.session, result.originalHash, result.isNew);
   }
@@ -279,6 +296,25 @@ module.exports = function (options) {
       touchSession = true;
       this._session = value;
     });
+
+    var self = this
+    this.regenerateSession = function *regenerateSession() {
+      debug('regenerating session');
+      // make sure that the session has been loaded
+      yield self.session
+      if (!isNew) {
+        // destroy the old session
+        debug('destroying previous session')
+        yield store.destroy(self.sessionId);
+      }
+
+      self._session = generateSession();
+      self.sessionId = genSid.call(this, 24);
+      self.cookies.set(key, null);
+      debug('created new session: %s', self.sessionId)
+      isNew = true;
+      return self._session;
+    }
 
     yield *next;
 

--- a/test/defer.test.js
+++ b/test/defer.test.js
@@ -148,5 +148,27 @@ describe('test/defer.test.js', function () {
       .get('/session/rewrite')
       .expect({foo: 'bar'}, done);
     });
+
+    it('should regenerate existing sessions', function (done) {
+      var agent = request.agent(app)
+      agent
+      .get('/session/get')
+      .expect(/.+/, function(err, res) {
+        var firstId = res.body;
+        agent
+        .get('/session/regenerate')
+        .expect(/.+/, function(err, res) {
+          var secondId = res.body;
+          secondId.should.not.equal(firstId);
+          done();
+        });
+      });
+    });
+
+    it('should regenerate new sessions', function (done) {
+      request(app)
+      .get('/session/regenerateWithData')
+      .expect({ /* foo: undefined, */ hasSession: true }, done);
+    });
   });
 });

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -178,5 +178,27 @@ describe('test/koa-session.test.js', function () {
             .expect(new RegExp(val), done);
         });
     });
+
+    it('should regenerate existing sessions', function (done) {
+      var agent = request.agent(app)
+      agent
+        .get('/session/get')
+        .expect(/.+/, function(err, res) {
+          var firstId = res.body;
+          agent
+            .get('/session/regenerate')
+            .expect(/.+/, function(err, res) {
+              var secondId = res.body;
+              secondId.should.not.equal(firstId);
+              done();
+            });
+        });
+    });
+
+    it('should regenerate new sessions', function (done) {
+      request(app)
+        .get('/session/regenerateWithData')
+        .expect({ /* foo: undefined, */ hasSession: true }, done);
+    });
   });
 });

--- a/test/support/defer.js
+++ b/test/support/defer.js
@@ -72,6 +72,15 @@ app.use(function *controllers() {
   case '/session/httponly':
     yield switchHttpOnly(this);
     break;
+  case '/session/regenerate':
+    yield regenerate(this);
+    break;
+  case '/session/regenerateWithData':
+    var session = yield this.session;
+    session.foo = 'bar';
+    session = yield regenerate(this);
+    this.body = { foo : session.foo, hasSession: session !== undefined };
+    break;
   default:
     yield other(this);
   }
@@ -107,6 +116,13 @@ function *switchHttpOnly(ctx) {
 
 function *other(ctx) {
   ctx.body = ctx.session ? 'has session' : 'no session';
+}
+
+function *regenerate(ctx) {
+  var session = yield ctx.regenerateSession();
+  session.data = 'foo';
+  ctx.body = ctx.sessionId
+  return session;
 }
 
 // app.listen(7001)

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -63,7 +63,7 @@ app.use(session({
 app.use(function *controllers() {
   switch (this.request.path) {
   case '/favicon.ico':
-    this.staus = 404;
+    this.status = 404;
     break;
   case '/wrongpath':
     this.body = !this.session ? 'no session' : 'has session';
@@ -89,6 +89,14 @@ app.use(function *controllers() {
     break;
   case '/session/id':
     getId(this);
+    break;
+  case '/session/regenerate':
+    yield regenerate(this);
+    break;
+  case '/session/regenerateWithData':
+    this.session.foo = 'bar';
+    yield regenerate(this);
+    this.body = { foo: this.session.foo, hasSession: this.session !== undefined };
     break;
   default:
     other(this);
@@ -122,6 +130,12 @@ function other(ctx) {
 
 function getId(ctx) {
   ctx.body = ctx.sessionId;
+}
+
+function *regenerate(ctx) {
+  yield ctx.regenerateSession();
+  ctx.session.data = 'foo';
+  getId(ctx);
 }
 
 var app = module.exports = http.createServer(app.callback());


### PR DESCRIPTION
This adds a method onto the context (regenerateSession) that can be used for destroying and re-creating a session mid-request, thereby creating a new session ID, and destroying any session data associated with the previous ID (if it was saved).

This makes it easier to follow OWASP guidelines for session management (See https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Renew_the_Session_ID_After_Any_Privilege_Level_Change).

Closes #40. Closes #41.