### PR TITLE
Don't fail on sufficiently brief store disconnect/reconnect glitches.

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -58,6 +58,7 @@ module.exports = function (options) {
   var key = options.key || 'koa.sid';
   var client = options.store || new MemoryStore();
   var errorHandler = options.errorHandler || defaultErrorHanlder;
+  var reconnectTimeout = options.reconnectTimeout || 15000;
 
   var store = new Store(client, {
     ttl: options.ttl,
@@ -77,7 +78,7 @@ module.exports = function (options) {
   var getConnect = Promise.resolve();
   store.once('disconnect', function(){
     getConnect = new Promise(function resolver(resolve, reject) {
-      var wait = 100; // maybe this could be configurable?
+      var wait = reconnectTimeout;
       setTimeout(function() {
         // fail current waiters...
         reject(new Error('session failed to reconnect after ' + wait + ' ms'));

--- a/lib/session.js
+++ b/lib/session.js
@@ -69,15 +69,27 @@ module.exports = function (options) {
   var cookie = options.cookie || {};
   copy(defaultCookie).to(cookie);
 
-  var storeAvailable = true;
-
   // notify user that this store is not
   // meant for a production environment
   if ('production' === process.env.NODE_ENV
    && client instanceof MemoryStore) console.warn(warning);
 
-  store.on('disconnect', function() { storeAvailable = false; });
-  store.on('connect', function() { storeAvailable = true; });
+  var getConnect = Promise.resolve();
+  store.once('disconnect', function(){
+    getConnect = new Promise(function resolver(resolve, reject) {
+      var wait = 100; // maybe this could be configurable?
+      setTimeout(function() {
+        // fail current waiters...
+        reject(new Error('session failed to reconnect after ' + wait + ' ms'));
+        // ...but give future waiters a chance
+        getConnect = new Promise(resolver);
+      }, wait);
+      store.once('connect', resolve);
+      store.once('disconnect', function() {
+        getConnect = new Promise(resolver);
+      });
+    });
+  });
 
   // save empty session hash for compare
   var EMPTY_SESSION_HASH = hash(generateSession());
@@ -117,10 +129,8 @@ module.exports = function (options) {
    *   get session from store
    */
   function *getSession() {
-    if (!storeAvailable) {
-      debug('store is disconnect');
-      throw new Error('session store error');
-    }
+
+    yield getConnect;
 
     if (!matchPath(this)) return;
 

--- a/test/support/defer.js
+++ b/test/support/defer.js
@@ -32,7 +32,8 @@ app.use(session({
     path: '/session',
   },
   defer: true,
-  store: store
+  store: store,
+  reconnectTimeout: 100
 }));
 
 // will ignore repeat session
@@ -42,7 +43,8 @@ app.use(session({
     maxAge: 86400,
     path: '/session'
   },
-  defer: true
+  defer: true,
+  reconnectTimeout: 100
 }));
 
 app.use(function *controllers() {

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -45,7 +45,8 @@ app.use(session({
   store: store,
   genSid: function(len) {
     return uid(len) + this.request.query.test_sid_append;
-  }
+  },
+  reconnectTimeout: 100
 }));
 
 // will ignore repeat session
@@ -57,7 +58,8 @@ app.use(session({
   },
   genSid: function(len) {
     return uid(len) + this.request.query.test_sid_append;
-  }
+  },
+  reconnectTimeout: 100
 }));
 
 app.use(function *controllers() {


### PR DESCRIPTION
In my prod environment the redis client for our sessions has been occasionally disconnecting and reconnecting, and I haven't figured out the exact cause yet. Someone inevitably hits the server during one of the "gaps" causing it to throw.

See here: https://github.com/koajs/koa-redis/issues/6#issuecomment-78543426

It's an error condition if the client disconnects and remains disconnected. But should a quick disconnect/reconnect be tolerated? That's what this PR attempts to do and also adds a `reconnectTimeout` option to make the tolerance configurable.