### PR TITLE
Added session id storage option to override session id store logic.

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -51,6 +51,7 @@ var defaultCookie = {
  *     you should `yield this.session` to get the session if defer is true, default is false
  *   - [`genSid`] you can use your own generator for sid
  *   - [`errorHanlder`] handler for session store get or set error
+ *   - [`sessionIdStore`] object with get, set, reset methods for passing session id throw requests.
  */
 
 module.exports = function (options) {
@@ -77,6 +78,23 @@ module.exports = function (options) {
   // meant for a production environment
   if ('production' === process.env.NODE_ENV
    && client instanceof MemoryStore) console.warn(warning);
+
+  var sessionIdStore = options.sessionIdStore || {
+
+    get: function() {
+      return this.cookies.get(key, {
+        signed: cookie.signed
+      });
+    },
+
+    set: function(sid, session) {
+      this.cookies.set(key, sid, session.cookie);
+    },
+
+    reset: function() {
+      this.cookies.set(key, null);
+    }
+  };
 
   store.on('disconnect', function() {
     if (storeStatus !== 'avaliable') return;
@@ -144,9 +162,7 @@ module.exports = function (options) {
     }
 
     if (!this.sessionId) {
-      this.sessionId = this.cookies.get(key, {
-        signed: cookie.signed
-      });
+      this.sessionId = sessionIdStore.get.call(this);
     }
 
     var session;
@@ -174,7 +190,7 @@ module.exports = function (options) {
       debug('can not get with key:%s from session store, generate a new one', this.sessionId);
       session = generateSession();
       this.sessionId = genSid.call(this, 24);
-      this.cookies.set(key, null);
+      sessionIdStore.reset.call(this);
       isNew = true;
     }
 
@@ -198,7 +214,7 @@ module.exports = function (options) {
     if (!session) {
       if (!isNew) {
         debug('session set to null, destroy session: %s', this.sessionId);
-        this.cookies.set(key, null);
+        sessionIdStore.reset.call(this);
         return yield store.destroy(this.sessionId);
       }
       return debug('a new session and set to null, ignore destroy');
@@ -221,7 +237,7 @@ module.exports = function (options) {
     //update session
     try {
       yield store.set(this.sessionId, session);
-      this.cookies.set(key, this.sessionId, session.cookie);
+      sessionIdStore.set.call(this, this.sessionId, session);
       debug('saved');
     } catch (err) {
       debug('set session error: ', err.message);
@@ -259,7 +275,8 @@ module.exports = function (options) {
 
       this.session = generateSession();
       this.sessionId = genSid.call(this, 24);
-      this.cookies.set(key, null);
+      sessionIdStore.reset.call(this);
+
       debug('created new session: %s', this.sessionId);
       result.isNew = true;
     }
@@ -328,7 +345,7 @@ module.exports = function (options) {
 
       this._session = generateSession();
       this.sessionId = genSid.call(this, 24);
-      this.cookies.set(key, null);
+      sessionIdStore.reset.call(this);
       debug('created new session: %s', this.sessionId);
       isNew = true;
       return this._session;
@@ -339,7 +356,7 @@ module.exports = function (options) {
     if (touchSession) {
       // if only this.session=, need try to decode and get the sessionID
       if (!getter) {
-        this.sessionId = this.cookies.get(key, {signed: cookie.signed});
+        this.sessionId = sessionIdStore.get.call(this);
       }
 
       yield *refreshSession.call(this, this._session, originalHash, isNew);


### PR DESCRIPTION
Hi! I want to be able pass session id in a different way. In headers for example. 
Now you can do this:
```javascript

genericSession({
  sessionIdStore: {

    get: function() {
      var header = this.header.authorization;
      if(!header) return;

      var match = header.match(/Token (.*)/i);
      if(match==null) return;

      return match[1];
    },

    set: function(){},
    reset: function(){}
  }
});
  
```