### PR TITLE
Fix typo of 'available'

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -71,7 +71,7 @@ module.exports = function (options) {
   var cookie = options.cookie || {};
   copy(defaultCookie).to(cookie);
 
-  var storeStatus = 'avaliable';
+  var storeStatus = 'available';
   var waitStore = Promise.resolve();
 
   // notify user that this store is not
@@ -97,12 +97,12 @@ module.exports = function (options) {
   };
 
   store.on('disconnect', function() {
-    if (storeStatus !== 'avaliable') return;
+    if (storeStatus !== 'available') return;
     storeStatus = 'pending';
     waitStore = new Promise(function (resolve, reject) {
       setTimeout(function () {
-        if (storeStatus === 'pending') storeStatus = 'unavaliable';
-        reject(new Error('session store is unavaliable'));
+        if (storeStatus === 'pending') storeStatus = 'unavailable';
+        reject(new Error('session store is unavailable'));
       }, reconnectTimeout);
       store.once('connect', resolve);
     });
@@ -110,7 +110,7 @@ module.exports = function (options) {
   });
 
   store.on('connect', function() {
-    storeStatus = 'avaliable';
+    storeStatus = 'available';
     waitStore = Promise.resolve();
   });
 
@@ -156,9 +156,9 @@ module.exports = function (options) {
     if (storeStatus === 'pending') {
       debug('store is disconnect and pending');
       yield waitStore;
-    } else if (storeStatus === 'unavaliable') {
-      debug('store is unavaliable');
-      throw new Error('session store is unavaliable');
+    } else if (storeStatus === 'unavailable') {
+      debug('store is unavailable');
+      throw new Error('session store is unavailable');
     }
 
     if (!this.sessionId) {

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -61,7 +61,7 @@ describe('test/store.test.js', function () {
       .expect('Internal Server Error', done);
     });
 
-    it('should error when status is unavaliable', function (done) {
+    it('should error when status is unavailable', function (done) {
       commonApp.store.emit('disconnect');
       setTimeout(function () {
         request(commonApp)


### PR DESCRIPTION
I spent a bit of time trying to grep for 'available' based on an error message I saw from this lib before realising there was a typo.