### PR TITLE
update default cookie maxage in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ app.listen(8080);
     {
       path: '/',
       httpOnly: true,
-      maxage: null,
+      maxage: 24 * 60 * 60 * 1000 //one day in ms,
       rewrite: true,
       signed: true
     }


### PR DESCRIPTION
The default cookie maxage in Readme doesn't align with the code https://github.com/koajs/generic-session/blob/master/lib/session.js#L37
