### PR TITLE
Don't generate new session for Websocket

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -170,6 +170,10 @@ module.exports = function (options) {
     let session;
     let isNew = false;
     if (!this.sessionId) {
+      if (this.req.upgrade) {
+        return
+      }
+
       debug('session id not exist, generate a new one');
       session = generateSession();
       this.sessionId = genSid.call(this, 24);


### PR DESCRIPTION
Forbid generating new session when being invoked from websocket session.
Use case: using this middleware from koa-websocket.
