### PR TITLE
Add koa-generic-session-knex link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ And use these events to report the store's status.
 - [koa-generic-session-rethinkdb](https://github.com/KualiCo/koa-generic-session-rethinkdb) to store your session data with ReThinkDB.
 - [koa-sqlite3-session](https://github.com/chichou/koa-sqlite3-session) to store your session data with SQLite3.
 - [koa-generic-session-sequelize](https://github.com/natesilva/koa-generic-session-sequelize) to store your session data with the [Sequelize](http://docs.sequelizejs.com/) ORM.
+- [koa-generic-session-knex](https://github.com/EarthlingInteractive/koa-generic-session-knex) to store your session data with the [Knex](http://knexjs.org/) query builder.
 
 ## Licences
 (The MIT License)


### PR DESCRIPTION
Updated the readme with a link to [koa-generic-session-knex](https://github.com/EarthlingInteractive/koa-generic-session-knex).