### PR TITLE
Refactor for koa 2

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,22 @@
+{
+  "parser": "babel-eslint",
+  "extends": "eslint:recommended",
+  "env": {
+    "es6": true,
+    "node": true,
+    "browser": false,
+    "commonjs": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 6
+  },
+  "rules": {
+    "indent": ["error", 2, { "SwitchCase": 1 }],
+    "linebreak-style": ["error", "unix"],
+    "quotes": ["error", "single"],
+    "semi": ["error", "never"],
+    "no-var": ["error"],
+    "prefer-const": ["error"],
+    "object-curly-spacing": ["error", "always"]
+  }
+}

--- a/example/app.js
+++ b/example/app.js
@@ -1,35 +1,35 @@
 
-var koa = require('koa');
-var session = require('..');
-var RedisStore = require('koa-redis');
+const koa = require('koa')
+const session = require('..')
+const RedisStore = require('koa-redis')
 
-var app = koa();
-app.keys = ['keys', 'keykeys'];
+const app = new koa()
+app.keys = ['keys', 'keykeys']
 app.use(session({
   store: new RedisStore()
-}));
+}))
 
-app.use(function *() {
-  switch (this.path) {
+app.use(ctx => {
+  switch (ctx.path) {
   case '/get':
-    get.call(this);
-    break;
+    get(ctx)
+    break
   case '/remove':
-    remove.call(this);
-    break;
+    remove(ctx)
+    break
   }
-});
+})
 
-function get() {
-  var session = this.session;
-  session.count = session.count || 0;
-  session.count++;
-  this.body = session.count;
+function get(ctx) {
+  const session = ctx.session
+  session.count = session.count || 0
+  session.count++
+  ctx.body = session.count
 }
 
-function remove() {
-  this.session = null;
-  this.body = 0;
+function remove(ctx) {
+  ctx.session = null
+  ctx.body = 0
 }
 
-app.listen(8080);
+app.listen(8080)

--- a/example/defer_app.js
+++ b/example/defer_app.js
@@ -1,36 +1,36 @@
 
-var koa = require('koa');
-var session = require('..');
-var RedisStore = require('koa-redis');
+const koa = require('koa')
+const session = require('..')
+const RedisStore = require('koa-redis')
 
-var app = koa();
-app.keys = ['keys', 'keykeys'];
+var app = koa()
+app.keys = ['keys', 'keykeys']
 app.use(session({
   defer: true,
   store: new RedisStore()
-}));
+}))
 
-app.use(function *() {
+app.use(ctx => {
   switch (this.path) {
   case '/get':
-    yield get.call(this);
-    break;
+    await get(ctx)
+    break
   case '/remove':
-    remove.call(this);
-    break;
+    remove(ctx)
+    break
   }
-});
+})
 
-function* get() {
-  var session = yield this.session;
-  session.count = session.count || 0;
-  session.count++;
-  this.body = session.count;
+async function get(ctx) {
+  const session = await ctx.session
+  session.count = session.count || 0
+  session.count++
+  ctx.body = session.count
 }
 
 function remove() {
-  this.session = null;
-  this.body = 0;
+  ctx.session = null
+  ctx.body = 0
 }
 
-app.listen(8080);
+app.listen(8080)

--- a/index.js
+++ b/index.js
@@ -1,2 +1,0 @@
-
-module.exports = require('./lib/session');

--- a/lib/memory_store.js
+++ b/lib/memory_store.js
@@ -7,28 +7,32 @@
  *   dead_horse <dead_horse@qq.com> (http://deadhorse.me)
  */
 
-'use strict';
+'use strict'
 
 /**
  * Module dependencies.
  */
 
-var debug = require('debug')('koa-generic-session:memory_store');
+const debug = require('debug')('koa-generic-session:memory_store')
 
-var MemoryStore = module.exports = function () {
-  this.sessions = {};
-};
+class MemoryStore {
+  constructor() {
+    this.sessions = {}
+  }
 
-MemoryStore.prototype.get = function *(sid) {
-  debug('get value %j with key %s', this.sessions[sid], sid);
-  return this.sessions[sid];
-};
+  get(sid) {
+    debug('get value %j with key %s', this.sessions[sid], sid)
+    return this.sessions[sid]
+  }
 
-MemoryStore.prototype.set = function *(sid, val) {
-  debug('set value %j for key %s', val, sid);
-  this.sessions[sid] = val;
-};
+  set(sid, val) {
+    debug('set value %j for key %s', val, sid)
+    this.sessions[sid] = val
+  }
 
-MemoryStore.prototype.destroy = function *(sid) {
-  delete this.sessions[sid];
-};
+  destroy(sid) {
+    delete this.sessions[sid]
+  }
+}
+
+module.exports = MemoryStore

--- a/lib/session.js
+++ b/lib/session.js
@@ -7,19 +7,19 @@
  *   dead_horse <dead_horse@qq.com> (http://deadhorse.me)
  */
 
-'use strict';
+
 
 /**
  * Module dependencies.
  */
 
-const debug = require('debug')('koa-generic-session:session');
-const MemoryStore = require('./memory_store');
-const crc32 = require('crc').crc32;
-const parse = require('parseurl');
-const Store = require('./store');
-const copy = require('copy-to');
-const uid = require('uid-safe');
+const debug = require('debug')('koa-generic-session:session')
+const MemoryStore = require('./memory_store')
+const crc32 = require('crc').crc32
+const parse = require('parseurl')
+const Store = require('./store')
+const copy = require('copy-to')
+const uid = require('uid-safe')
 
 /**
  * Warning message for `MemoryStore` usage in production.
@@ -27,7 +27,7 @@ const uid = require('uid-safe');
 
 const warning = 'Warning: koa-generic-session\'s MemoryStore is not\n' +
   'designed for a production environment, as it will leak\n' +
-  'memory, and will not scale past a single process.';
+  'memory, and will not scale past a single process.'
 
 const defaultCookie = {
   httpOnly: true,
@@ -35,7 +35,7 @@ const defaultCookie = {
   overwrite: true,
   signed: true,
   maxAge: 24 * 60 * 60 * 1000 //one day in ms
-};
+}
 
 /**
  * setup session store with the given `options`
@@ -56,113 +56,115 @@ const defaultCookie = {
  *   - [`sessionIdStore`] object with get, set, reset methods for passing session id throw requests.
  */
 
-module.exports = function (options) {
-  options = options || {};
-  let key = options.key || 'koa.sid';
-  let client = options.store || new MemoryStore();
-  let errorHandler = options.errorHandler || defaultErrorHanlder;
-  let reconnectTimeout = options.reconnectTimeout || 10000;
+module.exports = function(options = {}) {
 
-  let store = new Store(client, {
+  const key = options.key || 'koa.sid'
+  const client = options.store || new MemoryStore()
+  const errorHandler = options.errorHandler || defaultErrorHanlder
+  const reconnectTimeout = options.reconnectTimeout || 10000
+
+  const store = new Store(client, {
     ttl: options.ttl,
     prefix: options.prefix
-  });
+  })
 
-  let genSid = options.genSid || uid.sync;
-  let valid = options.valid || noop;
-  let beforeSave = options.beforeSave || noop;
+  const genSid = options.genSid || uid.sync
+  const valid = options.valid || noop
+  const beforeSave = options.beforeSave || noop
 
-  let cookie = options.cookie || {};
-  copy(defaultCookie).to(cookie);
+  const cookie = options.cookie || {}
+  copy(defaultCookie).to(cookie)
 
-  let storeStatus = 'available';
-  let waitStore = Promise.resolve();
+  let storeStatus = 'available'
+  let waitStore = Promise.resolve()
 
   // notify user that this store is not
   // meant for a production environment
-  if ('production' === process.env.NODE_ENV
-   && client instanceof MemoryStore) console.warn(warning);
+  if ('production' === process.env.NODE_ENV && client instanceof MemoryStore) {
+    // eslint-disable-next-line
+    console.warn(warning)
+  }
 
-  let sessionIdStore = options.sessionIdStore || {
+  const sessionIdStore = options.sessionIdStore || {
 
     get: function() {
-      return this.cookies.get(key, cookie);
+      return this.cookies.get(key, cookie)
     },
 
     set: function(sid, session) {
-      this.cookies.set(key, sid, session.cookie);
+      this.cookies.set(key, sid, session.cookie)
     },
 
     reset: function() {
-      this.cookies.set(key, null);
+      this.cookies.set(key, null)
     }
-  };
+  }
 
-  store.on('disconnect', function() {
-    if (storeStatus !== 'available') return;
-    storeStatus = 'pending';
-    waitStore = new Promise(function (resolve, reject) {
-      setTimeout(function () {
-        if (storeStatus === 'pending') storeStatus = 'unavailable';
-        reject(new Error('session store is unavailable'));
-      }, reconnectTimeout);
-      store.once('connect', resolve);
-    });
+  store.on('disconnect', () => {
+    if (storeStatus !== 'available') return
+    storeStatus = 'pending'
+    waitStore = new Promise((resolve, reject) => {
+      setTimeout(() => {
+        if (storeStatus === 'pending') storeStatus = 'unavailable'
+        reject(new Error('session store is unavailable'))
+      }, reconnectTimeout)
+      store.once('connect', resolve)
+    })
 
-  });
+  })
 
-  store.on('connect', function() {
-    storeStatus = 'available';
-    waitStore = Promise.resolve();
-  });
+  store.on('connect', () => {
+    storeStatus = 'available'
+    waitStore = Promise.resolve()
+  })
 
   // save empty session hash for compare
-  const EMPTY_SESSION_HASH = hash(generateSession());
+  const EMPTY_SESSION_HASH = hash(generateSession())
 
-  return options.defer ? deferSession : session;
+  return options.defer ? deferSession : session
 
-  function addCommonAPI() {
+  function addCommonAPI(ctx) {
 
-    this._sessionSave = null;
+    ctx._sessionSave = null
 
     // more flexible
-    this.__defineGetter__('sessionSave', function () {
-      return this._sessionSave;
-    });
+    ctx.__defineGetter__('sessionSave', function () {
+      return ctx._sessionSave
+    })
 
-    this.__defineSetter__('sessionSave', function (save) {
-      this._sessionSave = save;
-    });
+    ctx.__defineSetter__('sessionSave', function (save) {
+      ctx._sessionSave = save
+    })
   }
 
   /**
    * generate a new session
    */
   function generateSession() {
-    let session = {};
+    const session = {}
     //you can alter the cookie options in nexts
-    session.cookie = {};
-    for (let prop in cookie) {
-      session.cookie[prop] = cookie[prop];
+    session.cookie = {}
+    for (const prop in cookie) {
+      session.cookie[prop] = cookie[prop]
     }
-    compatMaxage(session.cookie);
-    return session;
+    compatMaxage(session.cookie)
+    return session
   }
 
   /**
    * check url match cookie's path
    */
   function matchPath(ctx) {
-    let pathname = parse(ctx).pathname;
-    let cookiePath = cookie.path || '/';
+    const pathname = parse(ctx).pathname
+    const cookiePath = cookie.path || '/'
     if (cookiePath === '/') {
-      return true;
+      return true
     }
     if (pathname.indexOf(cookiePath) !== 0) {
-      debug('cookie path not match');
-      return false;
+      debug('cookie path not match')
+      return false
     }
-    return true;
+    return true
   }
 
   /**
@@ -171,59 +173,59 @@ module.exports = function (options) {
    *   save sessionId into context
    *   get session from store
    */
-  function *getSession() {
-    if (!matchPath(this)) return;
+  async function getSession(ctx) {
+    if (!matchPath(ctx)) return
     if (storeStatus === 'pending') {
-      debug('store is disconnect and pending');
-      yield waitStore;
+      debug('store is disconnect and pending')
+      await waitStore
     } else if (storeStatus === 'unavailable') {
-      debug('store is unavailable');
-      throw new Error('session store is unavailable');
+      debug('store is unavailable')
+      throw new Error('session store is unavailable')
     }
 
-    if (!this.sessionId) {
-      this.sessionId = sessionIdStore.get.call(this);
+    if (!ctx.sessionId) {
+      ctx.sessionId = sessionIdStore.get.call(ctx)
     }
 
-    let session;
-    let isNew = false;
-    if (!this.sessionId) {
-      debug('session id not exist, generate a new one');
-      session = generateSession();
-      this.sessionId = genSid.call(this, 24);
-      isNew = true;
+    let session
+    let isNew = false
+    if (!ctx.sessionId) {
+      debug('session id not exist, generate a new one')
+      session = generateSession()
+      ctx.sessionId = genSid.call(ctx, 24)
+      isNew = true
     } else {
       try {
-        session = yield store.get(this.sessionId);
-        debug('get session %j with key %s', session, this.sessionId);
+        session = await store.get(ctx.sessionId)
+        debug('get session %j with key %s', session, ctx.sessionId)
       } catch (err) {
         if (err.code === 'ENOENT') {
-          debug('get session error, code = ENOENT');
+          debug('get session error, code = ENOENT')
         } else {
-          debug('get session error: ', err.message);
-          errorHandler(err, 'get', this);
+          debug('get session error: ', err.message)
+          errorHandler(err, 'get', ctx)
         }
       }
     }
 
     // make sure the session is still valid
     if (!session ||
-      !valid(this, session)) {
-      debug('session is empty or invalid');
-      session = generateSession();
-      this.sessionId = genSid.call(this, 24);
-      sessionIdStore.reset.call(this);
-      isNew = true;
+      !valid(ctx, session)) {
+      debug('session is empty or invalid')
+      session = generateSession()
+      ctx.sessionId = genSid.call(ctx, 24)
+      sessionIdStore.reset.call(ctx)
+      isNew = true
     }
 
     // get the originHash
-    let originalHash = !isNew && hash(session);
+    const originalHash = !isNew && hash(session)
 
     return {
       originalHash: originalHash,
       session: session,
       isNew: isNew
-    };
+    }
   }
 
   /**
@@ -231,60 +233,60 @@ module.exports = function (options) {
    *   if session === null; delete it from store
    *   if session is modified, update cookie and store
    */
-  function *refreshSession (session, originalHash, isNew) {
+  async function refreshSession (ctx, session, originalHash, isNew) {
 
     // reject any session changes, and do not update session expiry
-    if(this._sessionSave === false) {
-      return debug('session save disabled');
+    if(ctx._sessionSave === false) {
+      return debug('session save disabled')
     }
 
     //delete session
     if (!session) {
       if (!isNew) {
-        debug('session set to null, destroy session: %s', this.sessionId);
-        sessionIdStore.reset.call(this);
-        return yield store.destroy(this.sessionId);
+        debug('session set to null, destroy session: %s', ctx.sessionId)
+        sessionIdStore.reset.call(ctx)
+        return store.destroy(ctx.sessionId)
       }
-      return debug('a new session and set to null, ignore destroy');
+      return debug('a new session and set to null, ignore destroy')
     }
 
     // force saving non-empty session
-    if(this._sessionSave === true) {
-      debug('session save forced');
-      return yield saveNow.call(this, this.sessionId, session);
+    if(ctx._sessionSave === true) {
+      debug('session save forced')
+      return saveNow(ctx, ctx.sessionId, session)
     }
 
-    let newHash = hash(session);
+    const newHash = hash(session)
     // if new session and not modified, just ignore
     if (!options.allowEmpty && isNew && newHash === EMPTY_SESSION_HASH) {
-      return debug('new session and do not modified');
+      return debug('new session and do not modified')
     }
 
     // rolling session will always reset cookie and session
     if (!options.rolling && newHash === originalHash) {
-      return debug('session not modified');
+      return debug('session not modified')
     }
 
-    debug('session modified');
+    debug('session modified')
 
-    yield saveNow.call(this, this.sessionId, session);
+    await saveNow(ctx, ctx.sessionId, session)
 
   }
 
-  function *saveNow(id, session) {
-    compatMaxage(session.cookie);
+  async function saveNow(ctx, id, session) {
+    compatMaxage(session.cookie)
 
     // custom before save hook
-    beforeSave(this, session);
+    beforeSave(ctx, session)
 
     //update session
     try {
-      yield store.set(id, session);
-      sessionIdStore.set.call(this, id, session);
-      debug('saved');
+      await store.set(id, session)
+      sessionIdStore.set.call(ctx, id, session)
+      debug('saved')
     } catch (err) {
-      debug('set session error: ', err.message);
-      errorHandler(err, 'set', this);
+      debug('set session error: ', err.message)
+      errorHandler(err, 'set', ctx)
     }
   }
 
@@ -293,65 +295,65 @@ module.exports = function (options) {
    * each request will generate a new session
    *
    * ```
-   * let session = this.session;
+   * let session = this.session
    * ```
    */
-  function *session(next) {
-    this.sessionStore = store;
-    if (this.session || this._session) {
-      return yield next;
+  async function session(ctx, next) {
+    ctx.sessionStore = store
+    if (ctx.session || ctx._session) {
+      return next()
     }
-    let result = yield getSession.call(this);
+    const result = await getSession(ctx)
     if (!result) {
-      return yield next;
+      return next()
     }
 
-    addCommonAPI.call(this);
+    addCommonAPI(ctx)
 
-    this._session = result.session;
+    ctx._session = result.session
 
     // more flexible
-    this.__defineGetter__('session', function () {
-      return this._session;
-    });
+    ctx.__defineGetter__('session', function () {
+      return this._session
+    })
 
-    this.__defineSetter__('session', function (sess) {
-      this._session = sess;
-    });
+    ctx.__defineSetter__('session', function (sess) {
+      this._session = sess
+    })
 
-    this.regenerateSession = function *regenerateSession() {
-      debug('regenerating session');
+    ctx.regenerateSession = async function regenerateSession() {
+      debug('regenerating session')
       if (!result.isNew) {
         // destroy the old session
-        debug('destroying previous session');
-        yield store.destroy(this.sessionId);
+        debug('destroying previous session')
+        await store.destroy(ctx.sessionId)
       }
 
-      this.session = generateSession();
-      this.sessionId = genSid.call(this, 24);
-      sessionIdStore.reset.call(this);
+      ctx.session = generateSession()
+      ctx.sessionId = genSid.call(ctx, 24)
+      sessionIdStore.reset.call(ctx)
 
-      debug('created new session: %s', this.sessionId);
-      result.isNew = true;
+      debug('created new session: %s', ctx.sessionId)
+      result.isNew = true
     }
 
     // make sure `refreshSession` always called
-    var firstError = null;
+    let firstError = null
     try {
-      yield next;
+      await next()
     } catch (err) {
-      debug('next logic error: %s', err.message);
-      firstError = err;
+      debug('next logic error: %s', err.message)
+      firstError = err
     }
     // can't use finally because `refreshSession` is async
     try {
-      yield refreshSession.call(this, this.session, result.originalHash, result.isNew);
+      await refreshSession(ctx, ctx.session, result.originalHash, result.isNew)
     } catch (err) {
-      debug('refresh session error: %s', err.message);
-      if (firstError) this.app.emit('error', err, this);
-      firstError = firstError || err;
+      debug('refresh session error: %s', err.message)
+      if (firstError) ctx.app.emit('error', err, ctx)
+      firstError = firstError || err
     }
-    if (firstError) throw firstError;
+    if (firstError) throw firstError
   }
 
   /**
@@ -359,87 +361,93 @@ module.exports = function (options) {
    * only generate and get session when request use session
    *
    * ```
-   * let session = yield this.session;
+   * let session = yield this.session
    * ```
    */
-  function *deferSession(next) {
-    this.sessionStore = store;
+  async function deferSession(ctx, next) {
+    ctx.sessionStore = store
 
-    if (this.session) {
-      return yield next;
+    if (ctx.__session_is_set) {
+      return next()
     }
-    let isNew = false;
-    let originalHash = null;
-    let touchSession = false;
-    let getter = false;
+    // TODO: the culprit
+    // if (ctx.session) {
+    //   return next()
+    // }
+    let isNew = false
+    let originalHash = null
+    let touchSession = false
+    let getter = false
 
     // if path not match
-    if (!matchPath(this)) {
-      return yield next;
+    if (!matchPath(ctx)) {
+      return next()
     }
 
-    addCommonAPI.call(this);
+    addCommonAPI(ctx)
 
-    this.__defineGetter__('session', function *() {
+    ctx.__session_is_set = true
+
+    ctx.__defineGetter__('session', async () => {
       if (touchSession) {
-        return this._session;
+        return ctx._session
       }
-      touchSession = true;
-      getter = true;
+      touchSession = true
+      getter = true
 
-      let result = yield getSession.call(this);
+      const result = await getSession(ctx)
       // if cookie path not match
       // this route's controller should never use session
-      if (!result) return;
+      if (!result) return
 
-      originalHash = result.originalHash;
-      isNew = result.isNew;
-      this._session = result.session;
-      return this._session;
-    });
+      originalHash = result.originalHash
+      isNew = result.isNew
+      ctx._session = result.session
+      return ctx._session
+    })
 
-    this.__defineSetter__('session', function (value) {
-      touchSession = true;
-      this._session = value;
-    });
+    ctx.__defineSetter__('session', (value) => {
+      touchSession = true
+      ctx._session = value
+    })
 
-    this.regenerateSession = function *regenerateSession() {
-      debug('regenerating session');
+    ctx.regenerateSession = async function regenerateSession() {
+      debug('regenerating session')
       // make sure that the session has been loaded
-      yield this.session;
+      await ctx.session
 
       if (!isNew) {
         // destroy the old session
-        debug('destroying previous session');
-        yield store.destroy(this.sessionId);
+        debug('destroying previous session')
+        await store.destroy(ctx.sessionId)
       }
 
-      this._session = generateSession();
-      this.sessionId = genSid.call(this, 24);
-      sessionIdStore.reset.call(this);
-      debug('created new session: %s', this.sessionId);
-      isNew = true;
-      return this._session;
+      ctx._session = generateSession()
+      ctx.sessionId = genSid.call(ctx, 24)
+      sessionIdStore.reset.call(ctx)
+      debug('created new session: %s', ctx.sessionId)
+      isNew = true
+      return ctx._session
     }
 
-    yield next;
+    await next()
 
     if (touchSession) {
       // if only this.session=, need try to decode and get the sessionID
       if (!getter) {
-        this.sessionId = sessionIdStore.get.call(this);
+        ctx.sessionId = sessionIdStore.get.call(ctx)
       }
 
-      yield refreshSession.call(this, this._session, originalHash, isNew);
+      await refreshSession(ctx, ctx._session, originalHash, isNew)
     }
   }
-};
+}
 
 /**
  * get the hash of a session include cookie options.
  */
 function hash(sess) {
-  return crc32.signed(JSON.stringify(sess));
+  return crc32.signed(JSON.stringify(sess))
 }
 
 /**
@@ -447,18 +455,18 @@ function hash(sess) {
  */
 function compatMaxage(opts) {
   if (opts) {
-    opts.maxAge = opts.maxage ? opts.maxage : opts.maxAge;
-    delete opts.maxage;
+    opts.maxAge = opts.maxage ? opts.maxage : opts.maxAge
+    delete opts.maxage
   }
 }
 
-module.exports.MemoryStore = MemoryStore;
+module.exports.MemoryStore = MemoryStore
 
-function defaultErrorHanlder (err, type, ctx) {
-  err.name = 'koa-generic-session ' + type + ' error';
-  throw err;
+function defaultErrorHanlder (err, type) {
+  err.name = 'koa-generic-session ' + type + ' error'
+  throw err
 }
 
 function noop () {
-  return true;
+  return true
 }

--- a/lib/session.js
+++ b/lib/session.js
@@ -128,13 +128,15 @@ module.exports = function(options = {}) {
     ctx._sessionSave = null
 
     // more flexible
-    ctx.__defineGetter__('sessionSave', function () {
-      return ctx._sessionSave
+    Object.defineProperty(ctx, 'sessionSave', {
+      get: () => {
+        return ctx._sessionSave
+      },
+      set: (save) => {
+        ctx._sessionSave = save
+      }
     })
 
-    ctx.__defineSetter__('sessionSave', function (save) {
-      ctx._sessionSave = save
-    })
   }
 
   /**
@@ -313,12 +315,13 @@ module.exports = function(options = {}) {
     ctx._session = result.session
 
     // more flexible
-    ctx.__defineGetter__('session', function () {
-      return this._session
-    })
-
-    ctx.__defineSetter__('session', function (sess) {
-      this._session = sess
+    Object.defineProperty(ctx, 'session', {
+      get() {
+        return this._session
+      },
+      set(sess) {
+        this._session = sess
+      }
     })
 
     ctx.regenerateSession = async function regenerateSession() {
@@ -367,13 +370,13 @@ module.exports = function(options = {}) {
   async function deferSession(ctx, next) {
     ctx.sessionStore = store
 
-    if (ctx.__session_is_set) {
+    // TODO:
+    // Accessing ctx.session when it's defined is causing problems
+    // because it has side effect. So, here we use a flag to determine
+    // that session property is already defined.
+    if (ctx.__isSessionDefined) {
       return next()
     }
-    // TODO: the culprit
-    // if (ctx.session) {
-    //   return next()
-    // }
     let isNew = false
     let originalHash = null
     let touchSession = false
@@ -386,30 +389,32 @@ module.exports = function(options = {}) {
 
     addCommonAPI(ctx)
 
-    ctx.__session_is_set = true
+    Object.defineProperty(ctx, 'session', {
+      async get() {
+        if (touchSession) {
+          return this._session
+        }
+        touchSession = true
+        getter = true
 
-    ctx.__defineGetter__('session', async () => {
-      if (touchSession) {
-        return ctx._session
+        const result = await getSession(this)
+        // if cookie path not match
+        // this route's controller should never use session
+        if (!result) return
+
+        originalHash = result.originalHash
+        isNew = result.isNew
+        this._session = result.session
+        return this._session
+      },
+      set(value) {
+        touchSession = true
+        this._session = value
       }
-      touchSession = true
-      getter = true
-
-      const result = await getSession(ctx)
-      // if cookie path not match
-      // this route's controller should never use session
-      if (!result) return
-
-      originalHash = result.originalHash
-      isNew = result.isNew
-      ctx._session = result.session
-      return ctx._session
     })
 
-    ctx.__defineSetter__('session', (value) => {
-      touchSession = true
-      ctx._session = value
-    })
+    // internal flag to determine that session is already defined
+    ctx.__isSessionDefined = true
 
     ctx.regenerateSession = async function regenerateSession() {
       debug('regenerating session')

--- a/lib/store.js
+++ b/lib/store.js
@@ -7,77 +7,75 @@
  *   dead_horse <dead_horse@qq.com> (http://deadhorse.me)
  */
 
-'use strict';
+'use strict'
 
 /**
  * Module dependencies.
  */
 
-var util = require('util');
-var EventEmitter = require('events').EventEmitter;
-var debug = require('debug')('koa-generic-session:store');
-var copy = require('copy-to');
+const EventEmitter = require('events').EventEmitter
+const debug = require('debug')('koa-generic-session:store')
+const copy = require('copy-to')
 
-var defaultOptions = {
+const defaultOptions = {
   prefix: 'koa:sess:'
-};
+}
 
-function Store(client, options) {
-  this.client = client;
-  this.options = {};
-  copy(options).and(defaultOptions).to(this.options);
-  EventEmitter.call(this);
+class Store extends EventEmitter {
+  constructor(client, options) {
+    super()
+    this.client = client
+    this.options = options
+    copy(options).and(defaultOptions).to(this.options)
 
-  // delegate client connect / disconnect event
-  if (typeof client.on === 'function') {
-    client.on('disconnect', this.emit.bind(this, 'disconnect'));
-    client.on('connect', this.emit.bind(this, 'connect'));
+    // delegate client connect / disconnect event
+    if (typeof client.on === 'function') {
+      client.on('disconnect', this.emit.bind(this, 'disconnect'))
+      client.on('connect', this.emit.bind(this, 'connect'))
+    }
+  }
+
+  async get(sid) {
+    sid = this.options.prefix + sid
+    debug('GET %s', sid)
+    const data = await this.client.get(sid)
+    if (!data) {
+      debug('GET empty')
+      return null
+    }
+    if (data && data.cookie && typeof data.cookie.expires === 'string') {
+      // make sure data.cookie.expires is a Date
+      data.cookie.expires = new Date(data.cookie.expires)
+    }
+    debug('GOT %j', data)
+    return data
+  }
+
+  async set(sid, sess) {
+    let ttl = this.options.ttl
+    if (!ttl) {
+      const maxAge = sess.cookie && sess.cookie.maxAge
+      if (typeof maxAge === 'number') {
+        ttl = maxAge
+      }
+      // if has cookie.expires, ignore cookie.maxAge
+      if (sess.cookie && sess.cookie.expires) {
+        ttl = Math.ceil(sess.cookie.expires.getTime() - Date.now())
+      }
+    }
+
+    sid = this.options.prefix + sid
+    debug('SET key: %s, value: %s, ttl: %d', sid, sess, ttl)
+    await this.client.set(sid, sess, ttl)
+    debug('SET complete')
+  }
+
+  async destroy(sid) {
+    sid = this.options.prefix + sid
+    debug('DEL %s', sid)
+    await this.client.destroy(sid)
+    debug('DEL %s complete', sid)
   }
 }
 
-util.inherits(Store, EventEmitter);
-
-Store.prototype.get = function *(sid) {
-  var data;
-  sid = this.options.prefix + sid;
-  debug('GET %s', sid);
-  data = yield this.client.get(sid);
-  if (!data) {
-    debug('GET empty');
-    return null;
-  }
-  if (data && data.cookie && typeof data.cookie.expires === 'string') {
-    // make sure data.cookie.expires is a Date
-    data.cookie.expires = new Date(data.cookie.expires);
-  }
-  debug('GOT %j', data);
-  return data;
-};
-
-Store.prototype.set = function *(sid, sess) {
-  var ttl = this.options.ttl;
-  if (!ttl) {
-    var maxAge = sess.cookie && sess.cookie.maxAge;
-    if (typeof maxAge === 'number') {
-      ttl = maxAge;
-    }
-    // if has cookie.expires, ignore cookie.maxAge
-    if (sess.cookie && sess.cookie.expires) {
-      ttl = Math.ceil(sess.cookie.expires.getTime() - Date.now());
-    }
-  }
-
-  sid = this.options.prefix + sid;
-  debug('SET key: %s, value: %s, ttl: %d', sid, sess, ttl);
-  yield this.client.set(sid, sess, ttl);
-  debug('SET complete');
-};
-
-Store.prototype.destroy = function *(sid) {
-  sid = this.options.prefix + sid;
-  debug('DEL %s', sid);
-  yield this.client.destroy(sid);
-  debug('DEL %s complete', sid);
-};
-
-module.exports = Store;
+module.exports = Store

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "description": "koa generic session store by memory, redis or others",
   "repository": "koajs/generic-session",
   "version": "1.11.5",
+  "main": "lib/session",
+  "engines": {
+    "node": ">= 7.6"
+  },
+  "license": "MIT",
   "files": [
     "lib",
     "index.js"
@@ -15,26 +20,25 @@
   "author": "dead_horse <dead_horse@qq.com>",
   "dependencies": {
     "copy-to": "~2.0.1",
-    "crc": "~3.4.0",
-    "debug": "*",
+    "crc": "~3.4.4",
+    "debug": "~2.6.3",
     "parseurl": "~1.3.1",
-    "uid-safe": "~2.1.1"
+    "uid-safe": "~2.1.4"
   },
   "devDependencies": {
-    "autod": "~2.1.3",
-    "blanket": "*",
-    "contributors": "*",
-    "istanbul-harmony": "*",
-    "koa": "^1.2.4",
-    "koa-redis": "~2.1.1",
-    "mm": "~1.5.0",
-    "mocha": "2",
-    "pedding": "^1.0.0",
-    "should": "~10.0.0",
-    "supertest": "~2.0.1"
+    "babel-eslint": "^7.2.2",
+    "eslint": "^3.19.0",
+    "istanbul": "^0.4.5",
+    "koa": "^2.2.0",
+    "mm": "^2.1.0",
+    "mocha": "^3.2.0",
+    "should": "^11.2.1",
+    "supertest": "^3.0.0"
   },
-  "engines": {
-    "node": ">= 0.11.9"
-  },
-  "license": "MIT"
+  "scripts": {
+    "lint": "eslint lib test",
+    "test": "NODE_ENV=test mocha --timeout 3000 --require should test/*.test.js",
+    "test-cov": "NODE_ENV=test istanbul cover _mocha -- -u exports --timeout 3000 --require should test/*.test.js",
+    "test-travis": "NODE_ENV=test istanbul cover _mocha --report lcovonly -- -u exports --reporter 3000 --timeout 3000 --require should test/*.test.js"
+  }
 }

--- a/test/defer.test.js
+++ b/test/defer.test.js
@@ -7,168 +7,168 @@
  *   dead_horse <dead_horse@qq.com> (http://deadhorse.me)
  */
 
-'use strict';
+/* eslint-env mocha */
 
 /**
  * Module dependencies.
  */
 
-var Session = require('..');
-var koa = require('koa');
-var app = require('./support/defer');
-var request = require('supertest');
-var mm = require('mm');
-var should = require('should');
-var EventEmitter = require('events').EventEmitter;
+// const Session = require('..')
+// const koa = require('koa')
+const app = require('./support/defer')
+const request = require('supertest')
+// const mm = require('mm')
+// const should = require('should')
+// const EventEmitter = require('events').EventEmitter
 
-describe('test/defer.test.js', function () {
+describe('test/defer.test.js', () => {
 
-  describe('use', function () {
-    var cookie;
-    var mockCookie = 'koa.sid=s:dsfdss.PjOnUyhFG5bkeHsZ1UbEY7bDerxBINnZsD5MUguEph8; path=/; httponly';
-    it('should GET /session/get ok', function (done) {
-      request(app)
-      .get('/session/get')
-      .expect(/1/)
-      .end(function (err, res) {
-        cookie = res.headers['set-cookie'].join(';');
-        done();
-      });
-    });
+  describe('use', () => {
+    let cookie
+    const mockCookie = 'koa.sid=s:dsfdss.PjOnUyhFG5bkeHsZ1UbEY7bDerxBINnZsD5MUguEph8; path=/; httponly'
 
-    it('should GET /session/get second ok', function (done) {
-      request(app)
-      .get('/session/get')
-      .set('cookie', cookie)
-      .expect(/2/, done);
-    });
+    it('should GET /session/get ok', async () => {
 
-    it('should GET /session/httponly ok', function (done) {
-      request(app)
-      .get('/session/httponly')
-      .set('cookie', cookie)
-      .expect(/httpOnly: false/, function (err, res) {
-        should.not.exist(err);
-        cookie = res.headers['set-cookie'].join(';');
-        cookie.indexOf('httponly').should.equal(-1);
-        cookie.indexOf('expires=').should.above(0);
-        request(app)
+      const res = await request(app)
+        .get('/session/get')
+        .expect(/1/)
+
+      cookie = res.headers['set-cookie'].join(';')
+    })
+
+    it('should GET /session/get second ok', () => {
+      return request(app)
         .get('/session/get')
         .set('cookie', cookie)
-        .expect(/3/, done);
-      });
-    });
+        .expect(/2/)
+    })
 
-    it('should GET /session/httponly twice ok', function (done) {
-      request(app)
+    it('should GET /session/httponly ok', async () => {
+      const res = await request(app)
+        .get('/session/httponly')
+        .set('cookie', cookie)
+        .expect(/httpOnly: false/)
+
+      cookie = res.headers['set-cookie'].join(';')
+      cookie.indexOf('httponly').should.equal(-1)
+      cookie.indexOf('expires=').should.above(0)
+
+      await request(app)
+        .get('/session/get')
+        .set('cookie', cookie)
+        .expect(/3/)
+    })
+
+    it('should GET /session/httponly twice ok', async () => {
+
+      const res = await request(app)
       .get('/session/httponly')
       .set('cookie', cookie)
-      .expect(/httpOnly: true/, function (err, res) {
-        should.not.exist(err);
-        cookie = res.headers['set-cookie'].join(';');
-        cookie.indexOf('httponly').should.above(0);
-        cookie.indexOf('expires=').should.above(0);
-        done();
-      });
-    });
+      .expect(/httpOnly: true/)
 
-    it('should another user GET /session/get ok', function (done) {
-      request(app)
-      .get('/session/get')
-      .expect(/1/, done);
-    });
+      cookie = res.headers['set-cookie'].join(';')
+      cookie.indexOf('httponly').should.above(0)
+      cookie.indexOf('expires=').should.above(0)
+    })
 
-    it('should GET /session/nothing ok', function (done) {
-      request(app)
+
+    it('should another user GET /session/get ok', () => {
+      return request(app)
+        .get('/session/get')
+        .expect(/1/)
+    })
+
+    it('should GET /session/nothing ok', () => {
+      return request(app)
         .get('/session/nothing')
         .set('cookie', cookie)
-        .expect(/3/, done);
-    });
+        .expect(/3/)
+    })
 
-    it('should GET /session/notuse response no session', function (done) {
-      request(app)
-      .get('/session/notuse')
-      .set('cookie', cookie)
-      .expect(/no session/, done);
-    });
+    it('should GET /session/notuse response no session', () => {
+      return request(app)
+        .get('/session/notuse')
+        .set('cookie', cookie)
+        .expect(/no session/)
+    })
 
-    it('should GET /wrongpath response no session', function (done) {
-      request(app)
-      .get('/wrongpath')
-      .set('cookie', cookie)
-      .expect(/no session/, done);
-    });
+    it('should GET /wrongpath response no session', () => {
+      return request(app)
+        .get('/wrongpath')
+        .set('cookie', cookie)
+        .expect(/no session/)
+    })
 
-    it('should wrong cookie GET /session/get ok', function (done) {
-      request(app)
-      .get('/session/get')
-      .set('cookie', mockCookie)
-      .expect(/1/, done);
-    });
+    it('should wrong cookie GET /session/get ok', () => {
+      return request(app)
+        .get('/session/get')
+        .set('cookie', mockCookie)
+        .expect(/1/)
+    })
 
-    it('should wrong cookie GET /session/get twice ok', function (done) {
-      request(app)
-      .get('/session/get')
-      .set('cookie', mockCookie)
-      .expect(/1/, done);
-    });
+    it('should wrong cookie GET /session/get twice ok', () => {
+      return request(app)
+        .get('/session/get')
+        .set('cookie', mockCookie)
+        .expect(/1/)
+    })
 
-    it('should GET /session/remove ok', function (done) {
-      request(app)
-      .get('/session/remove')
-      .set('cookie', cookie)
-      .expect(/0/, function () {
-        request(app)
+    it('should GET /session/remove ok', async () => {
+      await request(app)
+        .get('/session/remove')
+        .set('cookie', cookie)
+        .expect(/0/)
+
+      await request(app)
         .get('/session/get')
         .set('cookie', cookie)
-        .expect(/1/, done);
-      });
-    });
+        .expect(/1/)
+    })
 
-    it('should GET / error by session ok', function (done) {
-      request(app)
-      .get('/')
-      .expect(/no session/, done);
-    });
+    it('should GET / error by session ok', () => {
+      return request(app)
+        .get('/')
+        .expect(/no session/)
+    })
 
-    it('should GET /session ok', function (done) {
-      request(app)
-      .get('/session')
-      .expect(/has session/, done);
-    });
+    it('should GET /session ok', () => {
+      return request(app)
+        .get('/session')
+        .expect(/has session/)
+    })
 
-    it('should GET /session/remove before get ok', function (done) {
-      request(app)
-      .get('/session/remove')
-      .expect(/0/, done);
-    });
+    it('should GET /session/remove before get ok', () => {
+      return request(app)
+        .get('/session/remove')
+        .expect(/0/)
+    })
 
-    it('should rewrite session before get ok', function (done) {
-      request(app)
-      .get('/session/rewrite')
-      .expect({foo: 'bar'}, done);
-    });
+    it('should rewrite session before get ok', () => {
+      return request(app)
+        .get('/session/rewrite')
+        .expect({ foo: 'bar' })
+    })
 
-    it('should regenerate existing sessions', function (done) {
-      var agent = request.agent(app)
-      agent
-      .get('/session/get')
-      .expect(/.+/, function(err, res) {
-        var firstId = res.body;
-        agent
+    it('should regenerate existing sessions', async () => {
+      const agent = request.agent(app)
+      const res1 = await agent
+        .get('/session/get')
+        .expect(/.+/)
+
+      const firstId = res1.body
+
+      const res2 = await agent
         .get('/session/regenerate')
-        .expect(/.+/, function(err, res) {
-          var secondId = res.body;
-          secondId.should.not.equal(firstId);
-          done();
-        });
-      });
-    });
+        .expect(/.+/)
 
-    it('should regenerate new sessions', function (done) {
-      request(app)
-      .get('/session/regenerateWithData')
-      .expect({ /* foo: undefined, */ hasSession: true }, done);
-    });
-  });
-});
+      const secondId = res2.body
+      secondId.should.not.equal(firstId)
+    })
+
+    it('should regenerate new sessions', () => {
+      return request(app)
+        .get('/session/regenerateWithData')
+        .expect({ /* foo: undefined, */ hasSession: true })
+    })
+  })
+})

--- a/test/override.test.js
+++ b/test/override.test.js
@@ -7,48 +7,50 @@
  *   Evan King <evan.king@bluespurs.com> (http://honoredsoft.com)
  */
 
-'use strict';
+/* eslint-env mocha */
 
 /**
  * Module dependencies.
  */
 
-var app = require('./support/override');
-var request = require('supertest');
-var mm = require('mm');
-var should = require('should');
+const app = require('./support/override')
+const request = require('supertest')
+// const mm = require('mm')
+const should = require('should')
 
-describe('test/override.test.js', function () {
-  var cookie;
-  before(function (done) {
-    request(app)
-    .get('/session/update')
-    .expect(/1/)
-    .end(function (err, res) {
-      cookie = res.headers['set-cookie'].join(';');
-      done(err);
-    });
-  });
+describe('test/override.test.js', () => {
+  let cookie
 
-  function req(path, expectBody, expectCookie, done) {
-    request(app)
+  before(async () => {
+
+    const res = await request(app)
+      .get('/session/update')
+      .expect(/1/)
+
+    cookie = res.headers['set-cookie'].join(';')
+  })
+
+
+  async function req(path, expectBody, expectCookie) {
+
+    const res = await request(app)
       .get('/session/' + path)
       .set('cookie', cookie)
-      .end(function (err, res) {
-        should(res.text).match(expectBody);
-        (expectCookie)
-          ? should.exist(res.headers['set-cookie'])
-          : should.not.exist(res.headers['set-cookie']);
-        done(err);
-      });
+
+    should(res.text).match(expectBody)
+
+    return expectCookie
+      ? should.exist(res.headers['set-cookie'])
+      : should.not.exist(res.headers['set-cookie'])
+
   }
 
-  it('should save modified session', req.bind(null, 'update', /2, null/, true));
-  it('should prevent saving modified session', req.bind(null, 'update/prevent', /3, false/, false));
-  it('should force saving unmodified session', req.bind(null, 'read/force', /2, true/, true));
-  it('should prevent deleting session', req.bind(null, 'remove/prevent', /0, false/, false));
-  it('should not have fresh session', req.bind(null, 'read', /2, null/, false));
-  it('should delete session on force-save', req.bind(null, 'remove/force', /0, true/, true));
-  it('should have fresh session', req.bind(null, 'read', /0, null/, true));
+  it('should save modified session', req.bind(null, 'update', /2, null/, true))
+  it('should prevent saving modified session', req.bind(null, 'update/prevent', /3, false/, false))
+  it('should force saving unmodified session', req.bind(null, 'read/force', /2, true/, true))
+  it('should prevent deleting session', req.bind(null, 'remove/prevent', /0, false/, false))
+  it('should not have fresh session', req.bind(null, 'read', /2, null/, false))
+  it('should delete session on force-save', req.bind(null, 'remove/force', /0, true/, true))
+  it('should have fresh session', req.bind(null, 'read', /0, null/, true))
 
-});
+})

--- a/test/rolling.test.js
+++ b/test/rolling.test.js
@@ -7,66 +7,66 @@
  *   dead_horse <dead_horse@qq.com> (http://deadhorse.me)
  */
 
-'use strict';
+/* eslint-env mocha */
 
 /**
  * Module dependencies.
  */
 
-var app = require('./support/rolling');
-var request = require('supertest');
-var mm = require('mm');
-var should = require('should');
+const app = require('./support/rolling')
+const request = require('supertest')
+// const mm = require('mm')
+const should = require('should')
 
-describe('test/rolling.test.js', function () {
-  var cookie;
-  beforeEach(function (done) {
-    request(app)
-    .get('/session/get')
-    .expect(/1/)
-    .end(function (err, res) {
-      cookie = res.headers['set-cookie'].join(';');
-      done(err);
-    });
-  });
+describe('test/rolling.test.js', () => {
+  let cookie
 
-  it('should get session success', function (done) {
-    request(app)
-    .get('/session/get')
-    .set('cookie', cookie)
-    .expect(/2/, done);
-  });
+  beforeEach(async () => {
 
-  it('should remove session success', done => {
-    request(app)
-    .get('/session/remove')
-    .set('cookie', cookie)
-    .end(function() {
-      request(app)
+    const res = await request(app)
+      .get('/session/get')
+      .expect(/1/)
+
+    cookie = res.headers['set-cookie'].join(';')
+  })
+
+  it('should get session success', () => {
+    return request(app)
       .get('/session/get')
       .set('cookie', cookie)
-      .expect(/1/, done);
-    });
-  });
+      .expect(/2/)
+  })
+
+  it('should remove session success', async () => {
+
+    await request(app)
+      .get('/session/remove')
+      .set('cookie', cookie)
+
+    await request(app)
+    .get('/session/get')
+    .set('cookie', cookie)
+    .expect(/1/)
+  })
 
   describe('when not modify session', () => {
-    it('and session exists get set-cookie', done => {
-      request(app)
-      .get('/session/nothing')
-      .set('cookie', cookie)
-      .end(function(err, res) {
-        should.exist(res.headers['set-cookie']);
-        done();
-      });
-    });
 
-    it('and session not exists don\'t get set-cookie', done => {
-      request(app)
-      .get('/session/nothing')
-      .end(function(err, res) {
-        should.not.exist(res.headers['set-cookie']);
-        done();
-      });
-    });
-  });
-});
+    it('and session exists get set-cookie', async () => {
+
+      const res = await request(app)
+        .get('/session/nothing')
+        .set('cookie', cookie)
+
+      should.exist(res.headers['set-cookie'])
+    })
+
+    it('and session not exists don\'t get set-cookie', async () => {
+
+      const res = await request(app)
+        .get('/session/nothing')
+
+      should.not.exist(res.headers['set-cookie'])
+
+    })
+  })
+})

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -7,237 +7,235 @@
  *   dead_horse <dead_horse@qq.com> (http://deadhorse.me)
  */
 
-'use strict';
+/* eslint-env mocha */
 
 /**
  * Module dependencies.
  */
 
-var Session = require('..');
-var koa = require('koa');
-var app = require('./support/server');
-var request = require('supertest');
-var mm = require('mm');
-var should = require('should');
-var EventEmitter = require('events').EventEmitter;
+const Session = require('..')
+const app = require('./support/server')
+const request = require('supertest')
+const mm = require('mm')
+const should = require('should')
+const EventEmitter = require('events').EventEmitter
 
-describe('test/koa-session.test.js', function () {
-  describe('init', function () {
-    afterEach(mm.restore);
+describe('test/koa-session.test.js', () => {
+  describe('init', () => {
+    afterEach(mm.restore)
 
-    beforeEach(function (done) {
-      request(app)
-        .get('/session/remive')
-        .expect(200, done);
-    });
+    beforeEach(() => {
+      return request(app)
+      .get('/session/remive')
+      .expect(200)
+    })
 
-    it('should warn when in production', function (done) {
-      mm(process.env, 'NODE_ENV', 'production');
-      mm(console, 'warn', function (message) {
+    it('should warn when in production', (done) => {
+      mm(process.env, 'NODE_ENV', 'production')
+      mm(console, 'warn', (message) => {
         message.should.equal('Warning: koa-generic-session\'s MemoryStore is not\n' +
         'designed for a production environment, as it will leak\n' +
-        'memory, and will not scale past a single process.');
-        done();
-      });
+        'memory, and will not scale past a single process.')
+        done()
+      })
 
-      Session({secret: 'secret'});
-    });
+      Session({ secret: 'secret' })
+    })
 
-    it('should listen disconnect and connect', function () {
-      var store = new EventEmitter();
+    it('should listen disconnect and connect', () => {
+      const store = new EventEmitter()
       Session({
         secret: 'secret',
         store: store
-      });
-      store._events.disconnect.should.be.Function;
-      store._events.connect.should.be.Function;
-    });
-  });
+      })
+      store._events.disconnect.should.be.Function
+      store._events.connect.should.be.Function
+    })
+  })
 
-  describe('use', function () {
-    var cookie;
-    var mockCookie = 'koa.sid=s:dsfdss.PjOnUyhFG5bkeHsZ1UbEY7bDerxBINnZsD5MUguEph8; path=/; httponly';
-    it('should GET /session/get ok', function (done) {
-      request(app)
-      .get('/session/get')
-      .expect(/1/)
-      .end(function (err, res) {
-        cookie = res.headers['set-cookie'].join(';');
-        done();
-      });
-    });
+  describe('use', () => {
+    let cookie
+    const mockCookie = 'koa.sid=s:dsfdss.PjOnUyhFG5bkeHsZ1UbEY7bDerxBINnZsD5MUguEph8; path=/; httponly'
 
-    it('should GET /session/get second ok', function (done) {
-      request(app)
+    it('should GET /session/get ok', async () => {
+
+      const res = await request(app)
+        .get('/session/get')
+        .expect(/1/)
+      cookie = res.headers['set-cookie'].join(';')
+
+    })
+
+    it('should GET /session/get second ok', () => {
+      return request(app)
       .get('/session/get')
       .set('cookie', cookie)
-      .expect(/2/, done);
-    });
+      .expect(/2/)
+    })
 
-    it('should GET /session/httponly ok', function (done) {
-      request(app)
-      .get('/session/httponly')
-      .set('cookie', cookie)
-      .expect(/httpOnly: false/, function (err, res) {
-        should.not.exist(err);
-        cookie = res.headers['set-cookie'].join(';');
-        cookie.indexOf('httponly').should.equal(-1);
-        cookie.indexOf('expires=').should.above(0);
-        request(app)
+    it('should GET /session/httponly ok', async () => {
+
+      const res = await request(app)
+        .get('/session/httponly')
+        .set('cookie', cookie)
+        .expect(/httpOnly: false/)
+
+      cookie = res.headers['set-cookie'].join(';')
+      cookie.indexOf('httponly').should.equal(-1)
+      cookie.indexOf('expires=').should.above(0)
+      return request(app)
         .get('/session/get')
         .set('cookie', cookie)
-        .expect(/3/, done);
-      });
-    });
+        .expect(/3/)
+    })
 
-    it('should GET /session/httponly twice ok', function (done) {
-      request(app)
-      .get('/session/httponly')
-      .set('cookie', cookie)
-      .expect(/httpOnly: true/, function (err, res) {
-        should.not.exist(err);
-        cookie = res.headers['set-cookie'].join(';');
-        cookie.indexOf('httponly').should.above(0);
-        cookie.indexOf('expires=').should.above(0);
-        done();
-      });
-    });
+    it('should GET /session/httponly twice ok', async () => {
 
-    it('should another user GET /session/get ok', function (done) {
-      request(app)
-      .get('/session/get')
-      .expect(/1/, done);
-    });
+      const res = await request(app)
+        .get('/session/httponly')
+        .set('cookie', cookie)
+        .expect(/httpOnly: true/)
 
-    it('should GET /session/nothing ok', function (done) {
-      request(app)
+      cookie = res.headers['set-cookie'].join(';')
+      cookie.indexOf('httponly').should.above(0)
+      cookie.indexOf('expires=').should.above(0)
+
+    })
+
+    it('should another user GET /session/get ok', () => {
+      return request(app)
+        .get('/session/get')
+        .expect(/1/)
+    })
+
+    it('should GET /session/nothing ok', () => {
+      return request(app)
         .get('/session/nothing')
         .set('cookie', cookie)
-        .expect(/3/, done);
-    });
+        .expect(/3/)
+    })
 
-    it('should wrong cookie GET /session/get ok', function (done) {
-      request(app)
+    it('should wrong cookie GET /session/get ok', () => {
+      return request(app)
       .get('/session/get')
       .set('cookie', mockCookie)
-      .expect(/1/, done);
-    });
+      .expect(/1/)
+    })
 
-    it('should wrong cookie GET /session/get twice ok', function (done) {
-      request(app)
-      .get('/session/get')
-      .set('cookie', mockCookie)
-      .expect(/1/, done);
-    });
+    it('should wrong cookie GET /session/get twice ok', () => {
+      return request(app)
+        .get('/session/get')
+        .set('cookie', mockCookie)
+        .expect(/1/)
+    })
 
-    it('should GET /wrongpath response no session', function (done) {
-      request(app)
-      .get('/wrongpath')
-      .set('cookie', cookie)
-      .expect(/no session/, done);
-    });
+    it('should GET /wrongpath response no session', () => {
+      return request(app)
+        .get('/wrongpath')
+        .set('cookie', cookie)
+        .expect(/no session/)
+    })
 
-    it('should GET /session/remove ok', function (done) {
-      request(app)
-      .get('/session/remove')
-      .set('cookie', cookie)
-      .expect(/0/, function () {
-        request(app)
+    it('should GET /session/remove ok', async () => {
+      await request(app)
+        .get('/session/remove')
+        .set('cookie', cookie)
+        .expect(/0/)
+
+      await request(app)
         .get('/session/get')
         .set('cookie', cookie)
-        .expect(/1/, done);
-      });
-    });
+        .expect(/1/)
+    })
 
-    it('should GET / error by session ok', function (done) {
-      request(app)
-      .get('/')
-      .expect(/no session/, done);
-    });
+    it('should GET / error by session ok', () => {
+      return request(app)
+        .get('/')
+        .expect(/no session/)
+    })
 
-    it('should GET /session ok', function (done) {
-      request(app)
-      .get('/session')
-      .expect(/has session/, done);
-    });
+    it('should GET /session ok', () => {
+      return request(app)
+        .get('/session')
+        .expect(/has session/)
+    })
 
-    it('should rewrite session before get ok', function (done) {
-      request(app)
-      .get('/session/rewrite')
-      .expect({foo: 'bar', path: '/session/rewrite'}, done);
-    });
+    it('should rewrite session before get ok', () => {
+      return request(app)
+        .get('/session/rewrite')
+        .expect({ foo: 'bar', path: '/session/rewrite' })
+    })
 
-    it('should regenerate a new session when session invalid', function (done) {
-      request(app)
+    it('should regenerate a new session when session invalid', async () => {
+
+      await request(app)
         .get('/session/get')
-        .expect('1', function (err) {
-          should.not.exist(err);
-          request(app)
-            .get('/session/nothing?valid=false')
-            .expect('', function (err) {
-              should.not.exist(err);
-              request(app)
-                .get('/session/get')
-                .expect('1', done);
-            });
-        });
-    });
+        .expect('1')
 
-    it('should GET /session ok', function (done) {
-      request(app)
+      await request(app)
+        .get('/session/nothing?valid=false')
+        .expect('')
+
+      await request(app)
+        .get('/session/get')
+        .expect('1')
+
+    })
+
+    it('should GET /session ok', () => {
+      return request(app)
         .get('/session/id?test_sid_append=test')
-        .expect(/test$/, done);
-    });
+        .expect(/test$/)
+    })
 
-    it('should force a session id ok', function (done) {
-      request(app)
+    it('should force a session id ok', async () => {
+      const res = await request(app)
         .get('/session/get')
-        .expect(/.*/, function(err, res) {
-          should.not.exist(err);
-          cookie = res.headers['set-cookie'][0].split(';');
-          var val = cookie[0].split('=').pop();
-          request(app)
-            .get('/session/id?force_session_id=' + val)
-            .expect(new RegExp(val), done);
-        });
-    });
+        .expect(/.*/)
 
-    it('should regenerate existing sessions', function (done) {
-      var agent = request.agent(app);
-      agent
+      cookie = res.headers['set-cookie'][0].split(';')
+      const val = cookie[0].split('=').pop()
+
+      await request(app)
+        .get('/session/id?force_session_id=' + val)
+        .expect(new RegExp(val))
+    })
+
+    it('should regenerate existing sessions', async () => {
+
+      const agent = request.agent(app)
+      const res1 = await agent
         .get('/session/get')
-        .expect(/.+/, function(err, res) {
-          var firstId = res.body;
-          agent
-            .get('/session/regenerate')
-            .expect(/.+/, function(err, res) {
-              var secondId = res.body;
-              secondId.should.not.equal(firstId);
-              done();
-            });
-        });
-    });
+        .expect(/.+/)
 
-    it('should regenerate a new session', function (done) {
-      request(app)
+      const firstId = res1.body
+      const res2 = await agent
+        .get('/session/regenerate')
+        .expect(/.+/)
+
+      const secondId = res2.body
+      secondId.should.not.equal(firstId)
+    })
+
+    it('should regenerate a new session', () => {
+      return request(app)
         .get('/session/regenerateWithData')
-        .expect({ /* foo: undefined, */ hasSession: true }, done);
-    });
+        .expect({ /* foo: undefined, */ hasSession: true })
+    })
 
-    it('should always refreshSession', function(done) {
-      var cookie;
-      request(app)
-      .get('/session/get_error')
-      .expect(500)
-      .end(function(err, res) {
-        should.not.exist(err);
-        cookie = res.headers['set-cookie'].join(';');
-        should.exist(cookie);
-        request(app)
+    it('should always refreshSession', async () => {
+
+      const res = await request(app)
+        .get('/session/get_error')
+        .expect(500)
+
+      const cookie = res.headers['set-cookie'].join(';')
+      should.exist(cookie)
+      await request(app)
         .get('/session/get')
         .set('cookie', cookie)
-        .expect(/2/, done);
-      });
-    });
-  });
-});
+        .expect(/2/)
+
+    })
+  })
+})

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -7,195 +7,198 @@
  *   dead_horse <dead_horse@qq.com> (http://deadhorse.me)
  */
 
-'use strict';
+/* eslint-env mocha */
 
 /**
  * Module dependencies.
  */
 
-var Session = require('..');
-var koa = require('koa');
-var deferApp = require('./support/defer');
-var commonApp = require('./support/server');
-var request = require('supertest');
-var mm = require('mm');
-var should = require('should');
-var EventEmitter = require('events').EventEmitter;
+// const session = require('..')
+// const koa = require('koa')
+const deferApp = require('./support/defer')
+const commonApp = require('./support/server')
+const request = require('supertest')
+const mm = require('mm')
+// const should = require('should')
+// const EventEmitter = require('events').EventEmitter
 
-var cookie;
-describe('test/store.test.js', function () {
-  afterEach(mm.restore);
-  describe('common session middleware', function () {
-    afterEach(function () {
-      commonApp.store.emit('connect');
-      mm.restore();
-    });
-    var cookie;
-    var mockCookie = 'koa.sid=s:dsfdss.PjOnUyhFG5bkeHsZ1UbEY7bDerxBINnZsD5MUguEph8; path=/; httponly';
+describe('test/store.test.js', () => {
+  afterEach(mm.restore)
+  describe('common session middleware', () => {
+    afterEach(() => {
+      commonApp.store.emit('connect')
+      mm.restore()
+    })
+    let cookie
+    // let mockCookie = 'koa.sid=s:dsfdss.PjOnUyhFG5bkeHsZ1UbEY7bDerxBINnZsD5MUguEph8; path=/; httponly'
 
-    it('should get session error when disconnect', function (done) {
-      commonApp.store.emit('disconnect');
-      request(commonApp)
-      .get('/session/get')
-      .expect(500)
-      .expect('session store is unavailable', done);
-    });
-
-    it('should get session ok when reconnect', function (done) {
-      commonApp.store.emit('disconnect');
-      setTimeout(function () {
-        commonApp.store.emit('connect');
-      }, 10);
-      request(commonApp)
-      .get('/session/get')
-      .expect(200)
-      .expect('1', done);
-    });
-
-    it('should ignore disconnect event', function (done) {
-      commonApp.store.emit('disconnect');
-      commonApp.store.emit('disconnect');
-      request(commonApp)
-      .get('/session/get')
-      .expect(500)
-      .expect('session store is unavailable', done);
-    });
-
-    it('should error when status is unavailable', function (done) {
-      commonApp.store.emit('disconnect');
-      setTimeout(function () {
-        request(commonApp)
+    it('should get session error when disconnect', () => {
+      commonApp.store.emit('disconnect')
+      return request(commonApp)
         .get('/session/get')
         .expect(500)
-        .expect('session store is unavailable', done);
-      }, 200);
-    });
+        .expect('session store is unavailable')
+    })
 
-    it('should get session ok when store.get error but session not exist', function (done) {
-      mm.error(commonApp.store, 'get', 'mock error');
-      request(commonApp)
-      .get('/session/get')
-      .expect(/1/)
-      .expect(200, function (err, res) {
-        cookie = res.headers['set-cookie'].join(';');
-        cookie.indexOf('httponly').should.above(0);
-        cookie.indexOf('expires=').should.above(0);
-        done(err);
-      });
-    });
+    it('should get session ok when reconnect', () => {
+      commonApp.store.emit('disconnect')
+      setTimeout(() => {
+        commonApp.store.emit('connect')
+      }, 10)
+      return request(commonApp)
+        .get('/session/get')
+        .expect(200)
+        .expect('1')
+    })
 
-    it('should get session error when store.get error', function (done) {
-      mm(commonApp.store, 'get', function *() {
-        throw new Error('mock get error');
-      });
-      request(commonApp)
-      .get('/session/get')
-      .set('cookie', cookie)
-      .expect(500, done);
-    });
+    it('should ignore disconnect event', () => {
+      commonApp.store.emit('disconnect')
+      commonApp.store.emit('disconnect')
+      return request(commonApp)
+        .get('/session/get')
+        .expect(500)
+        .expect('session store is unavailable')
+    })
 
-    it('should get /session/notuse error when store.get error', function (done) {
-      mm(commonApp.store, 'get', function *() {
-        throw new Error('mock get error');
-      });
-      request(commonApp)
-      .get('/session/notuse')
-      .set('cookie', cookie)
-      .expect(500, done);
-    });
-
-    it('should handler session error when store.set error', function (done) {
-      request(commonApp)
-      .get('/session/get')
-      .set('cookie', cookie)
-      .expect(200)
-      .expect(/2/, function () {
-        mm(commonApp.store, 'set', function *() {
-          throw new Error('mock set error');
-        });
+    it('should error when status is unavailable', (done) => {
+      commonApp.store.emit('disconnect')
+      setTimeout(() => {
         request(commonApp)
+          .get('/session/get')
+          .expect(500)
+          .expect('session store is unavailable', done)
+      }, 200)
+    })
+
+    it('should get session ok when store.get error but session not exist', async () => {
+      mm.error(commonApp.store, 'get', 'mock error')
+      const res = await request(commonApp)
+        .get('/session/get')
+        .expect(/1/)
+        .expect(200)
+      cookie = res.headers['set-cookie'].join(';')
+      cookie.indexOf('httponly').should.above(0)
+      cookie.indexOf('expires=').should.above(0)
+    })
+
+
+
+
+    it('should get session error when store.get error', () => {
+      mm(commonApp.store, 'get', () => {
+        throw new Error('mock get error')
+      })
+      return request(commonApp)
         .get('/session/get')
         .set('cookie', cookie)
         .expect(500)
-        .expect('mock set error', done);
-      });
-    });
+    })
 
-    it('should handler session error when store.set error and logic error', function (done) {
-      mm(commonApp.store, 'set', function *() {
-        throw new Error('mock set error');
-      });
-      request(commonApp)
-      .get('/session/get_error')
-      .expect(500)
-      .expect('oops', done);
-    });
-  });
+    it('should get /session/notuse error when store.get error', () => {
+      mm(commonApp.store, 'get', () => {
+        throw new Error('mock get error')
+      })
+      return request(commonApp)
+        .get('/session/notuse')
+        .set('cookie', cookie)
+        .expect(500)
+    })
 
-  describe('defer session middleware', function () {
-    afterEach(function () {
-      deferApp.store.emit('connect');
-      mm.restore();
-    });
-    var cookie;
-    var mockCookie = 'koa.sid=s:dsfdss.PjOnUyhFG5bkeHsZ1UbEY7bDerxBINnZsD5MUguEph8; path=/; httponly';
-
-    it('should get session error when disconnect', function (done) {
-      deferApp.store.emit('disconnect');
-      request(deferApp)
-      .get('/session/get')
-      .expect(500)
-      .expect('session store is unavailable', done);
-    });
-
-    it('should get session ok when store.get error but session not exist', function (done) {
-      mm.error(deferApp.store, 'get', 'mock error');
-      request(deferApp)
-      .get('/session/get')
-      .expect(/1/)
-      .expect(200, function (err, res) {
-        cookie = res.headers['set-cookie'].join(';');
-        cookie.indexOf('httponly').should.above(0);
-        cookie.indexOf('expires=').should.above(0);
-        done(err);
-      });
-    });
-
-    it('should get session error when store.get error', function (done) {
-      mm(deferApp.store, 'get', function *() {
-        throw new Error('mock get error');
-      });
-      request(deferApp)
-      .get('/session/get')
-      .set('cookie', cookie)
-      .expect(500, done);
-    });
-
-    it('should get /session/notuse ok when store.get error', function (done) {
-      mm(deferApp.store, 'get', function *() {
-        throw new Error('mock get error');
-      });
-      request(deferApp)
-      .get('/session/notuse')
-      .set('cookie', cookie)
-      .expect(200, done);
-    });
-
-    it('should handler session error when store.set error', function (done) {
-      request(commonApp)
-      .get('/session/get')
-      .set('cookie', cookie)
-      .expect(200)
-      .expect(/2/, function () {
-        mm(commonApp.store, 'set', function *() {
-          throw new Error('mock set error');
-        });
-        request(commonApp)
+    it('should handler session error when store.set error', async () => {
+      await request(commonApp)
+        .get('/session/get')
+        .set('cookie', cookie)
+        .expect(200)
+        .expect(/2/)
+      mm(commonApp.store, 'set', () => {
+        throw new Error('mock set error')
+      })
+      await request(commonApp)
         .get('/session/get')
         .set('cookie', cookie)
         .expect(500)
-        .expect('mock set error', done);
-      });
-    });
-  });
-});
+        .expect('mock set error')
+
+    })
+
+    it('should handler session error when store.set error and logic error', () => {
+      mm(commonApp.store, 'set', () => {
+        throw new Error('mock set error')
+      })
+      return request(commonApp)
+        .get('/session/get_error')
+        .expect(500)
+        .expect('oops')
+    })
+  })
+
+  describe('defer session middleware', () => {
+    afterEach(() => {
+      deferApp.store.emit('connect')
+      mm.restore()
+    })
+    let cookie
+    const mockCookie = 'koa.sid=s:dsfdss.PjOnUyhFG5bkeHsZ1UbEY7bDerxBINnZsD5MUguEph8; path=/; httponly'
+
+    it('should get session error when disconnect', () => {
+      deferApp.store.emit('disconnect')
+      return request(deferApp)
+        .get('/session/get')
+        .expect(500)
+        .expect('session store is unavailable')
+    })
+
+    it('should get session ok when store.get error but session not exist', async () => {
+      mm.error(deferApp.store, 'get', 'mock error')
+      const res = await request(deferApp)
+        .get('/session/get')
+        .expect(/1/)
+        .expect(200)
+
+      cookie = res.headers['set-cookie'].join(';')
+      cookie.indexOf('httponly').should.above(0)
+      cookie.indexOf('expires=').should.above(0)
+
+    })
+
+    it('should get session error when store.get error', () => {
+      mm(deferApp.store, 'get', () => {
+        throw new Error('mock get error')
+      })
+      return request(deferApp)
+        .get('/session/get')
+        .set('cookie', cookie)
+        .expect(500)
+    })
+
+    it('should get /session/notuse ok when store.get error', () => {
+      mm(deferApp.store, 'get', () => {
+        throw new Error('mock get error')
+      })
+      return request(deferApp)
+        .get('/session/notuse')
+        .set('cookie', cookie)
+        .expect(200)
+    })
+
+    it('should handler session error when store.set error', (done) => {
+      cookie = 'koss:test_sid=bGX1r5jcQHX4CqO1Heiy_DLvkTpQvx3M; path=/session; expires=Thu, 13 Apr 2017 17:19:04 GMT; httponly;koss:test_sid.sig=ZvZ8W0x9akbySx-9kEUkVPqAd2g; path=/session; expires=Thu, 13 Apr 2017 17:19:04 GMT; httponly'
+      request(commonApp)
+        .get('/session/get')
+        .set('cookie', cookie)
+        .expect(200)
+        .expect(/2/, () => {
+          mm(commonApp.store, 'set', () => {
+            throw new Error('mock set error')
+          })
+          request(commonApp)
+            .get('/session/get')
+            .set('cookie', cookie)
+            .expect(500)
+            .expect('mock set error', done)
+        })
+    })
+
+  })
+
+})

--- a/test/support/override.js
+++ b/test/support/override.js
@@ -7,24 +7,24 @@
  *   Evan King <evan.king@bluespurs.com> (http://honoredsoft.com)
  */
 
-'use strict';
+
 
 /**
  * Module dependencies.
  */
-var koa = require('koa');
-var http = require('http');
-var session = require('../../');
-var Store = require('./store');
+const koa = require('koa')
+const http = require('http')
+const session = require('../..')
+const Store = require('./store')
 
-var app = koa();
+const app = new koa()
 
-app.name = 'koa-session-test';
-app.outputErrors = true;
-app.keys = ['keys', 'keykeys'];
-app.proxy = true; // to support `X-Forwarded-*` header
+app.name = 'koa-session-test'
+app.outputErrors = true
+app.keys = ['keys', 'keykeys']
+app.proxy = true // to support `X-Forwarded-*` header
 
-var store = new Store();
+const store = new Store()
 
 app.use(session({
   key: 'koss:test_sid',
@@ -36,50 +36,50 @@ app.use(session({
   },
   store: store,
   rolling: false,
-}));
+}))
 
-app.use(function *controllers() {
-  switch (this.request.path) {
-  case '/session/read/force':
-    this.sessionSave = true;
-  case '/session/read':
-    read(this);
-    break;
+app.use(function controllers(ctx) {
+  switch (ctx.request.path) {
+    case '/session/read/force':
+      ctx.sessionSave = true // eslint-disable-next-line
+    case '/session/read':
+      read(ctx)
+      break
 
-  case '/session/update/prevent':
-    this.sessionSave = false;
-  case '/session/update':
-    update(this);
-    break;
+    case '/session/update/prevent':
+      ctx.sessionSave = false // eslint-disable-next-line
+    case '/session/update':
+      update(ctx)
+      break
 
-  case '/session/remove/prevent':
-    this.sessionSave = false;
-    remove(this);
-    break;
+    case '/session/remove/prevent':
+      ctx.sessionSave = false
+      remove(ctx)
+      break
 
-  case '/session/remove/force':
-    this.sessionSave = true;
-    remove(this);
-    break;
+    case '/session/remove/force':
+      ctx.sessionSave = true
+      remove(ctx)
+      break
   }
 
-  this.body = this.body + ', ' + this.sessionSave;
-});
+  ctx.body = ctx.body + ', ' + ctx.sessionSave
+})
 
 function read(ctx) {
-  ctx.session.count = ctx.session.count || 0;
-  ctx.body = String(ctx.session.count);
+  ctx.session.count = ctx.session.count || 0
+  ctx.body = String(ctx.session.count)
 }
 
 function update(ctx) {
-  ctx.session.count = ctx.session.count || 0;
-  ctx.session.count++;
-  ctx.body = String(ctx.session.count);
+  ctx.session.count = ctx.session.count || 0
+  ctx.session.count++
+  ctx.body = String(ctx.session.count)
 }
 
 function remove(ctx) {
-  ctx.session = null;
-  ctx.body = '0';
+  ctx.session = null
+  ctx.body = '0'
 }
 
-var app = module.exports = http.createServer(app.callback());
+module.exports = http.createServer(app.callback())

--- a/test/support/rolling.js
+++ b/test/support/rolling.js
@@ -7,24 +7,24 @@
  *   dead_horse <dead_horse@qq.com> (http://deadhorse.me)
  */
 
-'use strict';
+
 
 /**
  * Module dependencies.
  */
-var koa = require('koa');
-var http = require('http');
-var session = require('../../');
-var Store = require('./store');
+const koa = require('koa')
+const http = require('http')
+const session = require('../..')
+const Store = require('./store')
 
-var app = koa();
+const app = new koa()
 
-app.name = 'koa-session-test';
-app.outputErrors = true;
-app.keys = ['keys', 'keykeys'];
-app.proxy = true; // to support `X-Forwarded-*` header
+app.name = 'koa-session-test'
+app.outputErrors = true
+app.keys = ['keys', 'keykeys']
+app.proxy = true // to support `X-Forwarded-*` header
 
-var store = new Store();
+const store = new Store()
 
 app.use(session({
   key: 'koss:test_sid',
@@ -36,34 +36,34 @@ app.use(session({
   },
   store: store,
   rolling: true,
-}));
+}))
 
-app.use(function *controllers() {
-  switch (this.request.path) {
-  case '/session/get':
-    get(this);
-    break;
-  case '/session/remove':
-    remove(this);
-    break;
-  case '/session/nothing':
-    nothing(this);
+app.use(function controllers(ctx) {
+  switch (ctx.request.path) {
+    case '/session/get':
+      get(ctx)
+      break
+    case '/session/remove':
+      remove(ctx)
+      break
+    case '/session/nothing':
+      nothing(ctx)
   }
-});
+})
 
 function get(ctx) {
-  ctx.session.count = ctx.session.count || 0;
-  ctx.session.count++;
-  ctx.body = ctx.session.count;
+  ctx.session.count = ctx.session.count || 0
+  ctx.session.count++
+  ctx.body = ctx.session.count
 }
 
 function remove(ctx) {
-  ctx.session = null;
-  ctx.body = 0;
+  ctx.session = null
+  ctx.body = 0
 }
 
 function nothing(ctx) {
-  ctx.body = 'do not touch session';
+  ctx.body = 'do not touch session'
 }
 
-var app = module.exports = http.createServer(app.callback());
+module.exports = http.createServer(app.callback())

--- a/test/support/store.js
+++ b/test/support/store.js
@@ -4,38 +4,39 @@
  * MIT Licensed
  */
 
-'use strict';
+'use strict'
 
 /**
  * Module dependencies.
  */
 
-var util = require('util');
-var EventEmitter = require('events').EventEmitter;
+const EventEmitter = require('events').EventEmitter
 
-var Store = module.exports = function () {
-  this.sessions = {};
-  EventEmitter.call(this);
-};
-
-util.inherits(Store, EventEmitter);
-
-Store.prototype.get = function *(sid) {
-  var session = this.sessions[sid];
-  if (!session) {
-    return null;
+class Store extends EventEmitter {
+  constructor(...args) {
+    super(...args)
+    this.sessions = {}
   }
-  var r = {};
-  for (var key in session) {
-    r[key] = session[key];
+
+  get(sid) {
+    const session = this.sessions[sid]
+    if (!session) {
+      return null
+    }
+    const r = {}
+    for (const key in session) {
+      r[key] = session[key]
+    }
+    return r
   }
-  return r;
-};
 
-Store.prototype.set = function *(sid, val) {
-  this.sessions[sid] = val;
-};
+  set(sid, val) {
+    this.sessions[sid] = val
+  }
 
-Store.prototype.destroy = function *(sid) {
-  delete this.sessions[sid];
-};
+  destroy(sid) {
+    delete this.sessions[sid]
+  }
+}
+
+module.exports = Store


### PR DESCRIPTION
I convert the sources to use `async/await` syntax for koa 2. All test passed, the tests has been rewritten too of course to be compatible with koa 2.

But, I think there is a serious problem in `ctx.session` getter/setter. It has side effect when accessing
`ctx.session` which can cause problem. Even though all tests pass, I think that getter/setter API
should be changed.