### PR TITLE
fix: copy cookie options instead of using reference

### DIFF
--- a/src/session.js
+++ b/src/session.js
@@ -72,7 +72,7 @@ module.exports = function(options = {}) {
   const valid = options.valid || noop
   const beforeSave = options.beforeSave || noop
 
-  const cookie = options.cookie || {}
+  const cookie = Object.assign({}, options.cookie)
   copy(defaultCookie).to(cookie)
 
   let storeStatus = 'available'


### PR DESCRIPTION
Since cookie options are flat, there's no need for a deep copy. It was probably a mistake that we're modifying the supplied options.