### PR TITLE
feat: allow TTL to be set dynamically

### DIFF
--- a/src/session.js
+++ b/src/session.js
@@ -42,7 +42,7 @@ const defaultCookie = {
  * @param {Object} options
  *   - [`key`] cookie name, defaulting to `koa.sid`
  *   - [`store`] session store instance, default to MemoryStore
- *   - [`ttl`] store ttl in `ms`, default to oneday
+ *   - [`ttl`] store ttl in `ms`, default to cookie maxAge/expires
  *   - [`prefix`] session prefix for store, defaulting to `koa:sess:`
  *   - [`cookie`] session cookie settings, defaulting to
  *     {path: '/', httpOnly: true, maxAge: null, overwrite: true, signed: true}

--- a/src/store.js
+++ b/src/store.js
@@ -52,7 +52,7 @@ class Store extends EventEmitter {
   }
 
   async set(sid, sess) {
-    let ttl = this.options.ttl
+    let ttl = typeof this.options.ttl === 'function' ? this.options.ttl(sess) : this.options.ttl;
     if (!ttl) {
       const maxAge = sess.cookie && sess.cookie.maxAge
       if (typeof maxAge === 'number') {


### PR DESCRIPTION
Currently, it's very common for websites to offer a "dynamic" session age ("remember for X/Y days", or disabling "remember" which wipes the cookie after browser is closed), however with the current implementation it's not possible to control TTL per request (for example, if cookie will have a `maxAge !== null`, use it, else use a default value). After this PR, consumers accomplish this result as this:

```typescript
{
  ttl: (session) => {
    if (session.cookie?.maxAge === null) {
      return 1000 * 60 * 60 * 24;
    }
  }
}
```

it would allow browser-session cookies to be removed after 1 day from the store and not live indefinitely like they do now.