### PR TITLE
feat: use cookie.httpOnly in reset

### DIFF
--- a/src/session.js
+++ b/src/session.js
@@ -98,7 +98,7 @@ module.exports = function(options = {}) {
 
     reset: function() {
       if (!this.headerSent || this.writeable)
-        this.cookies.set(key, null, { expires: new Date(0) })
+        this.cookies.set(key, null, { expires: new Date(0), httpOnly: cookie.httpOnly })
     }
   }
 


### PR DESCRIPTION
## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.

When a user sets `httpOnly: false`, the default behavior of `reset` might result in `document.cookie` not being updated on Safari browsers. This can lead to a mismatch between the cookie information in the application and the cookies obtained by the frontend. To ensure consistency in cookie data, I recommend referencing the behavior of `cookie.httpOnly` during the `reset` process.

Alternatively, should we consider using all configuration options available with cookies here?
